### PR TITLE
Added some optional layout functions to the mustache template

### DIFF
--- a/app/helpers/bobcat_helper.rb
+++ b/app/helpers/bobcat_helper.rb
@@ -88,4 +88,9 @@ module BobcatHelper
     args[2] = {"title" => args[0], "data-content" => "<div class=\"#{klass}\">#{content}</div>", :rel => "popover", :class => "#{klass}"}
     link_to(*args)
   end
+  
+  def two_column ; true end  
+  def onload ; false end
+  def body_class ; false end
+  def body_id ; false end
 end

--- a/app/templates/layouts/bobcat.mustache
+++ b/app/templates/layouts/bobcat.mustache
@@ -7,7 +7,7 @@
     {{stylesheets}}
     {{javascripts}}
   </head>
-  <body>
+  <body{{#onload}} onload="{{onload}}"{{/onload}}{{#body_class}} class="{{body_class}}"{{/body_class}}{{#body_id}} id="{{body_id}}"{{/body_id}}>
     <header id="header" class="header">
       <div class="parent"><a href="http://library.nyu.edu/"><span>NYU Libraries</span></a></div>
       <div class="suite"><span>{{suite}}</span></div>
@@ -26,7 +26,7 @@
     <div class="nyu-container">
       <div class="container-fluid">
         <div class="row-fluid">
-          <div class="span8">
+          <div class="{{#two_column}}span8{{/two_column}}{{^two_column}}span12{{/two_column}}">
             <ul class="nav nav-tabs">
               {{#tabs}}
                 <li class="{{klass}}" id="{{code}}">{{link}}</li>
@@ -34,6 +34,7 @@
             </ul>
             {{yield}}
           </div>
+          {{#two_column}}
           <div class="span4">
             <div id="sidebar" class="sidebar">
               <div id="sidebar_tabs" class="sidebar-section">
@@ -47,6 +48,7 @@
               {{sidebar}}
             </div>
           </div>
+          {{/two_column}}
         </div>
       </div>
     </div>

--- a/lib/assets/stylesheets/_nyulibraries.css.scss
+++ b/lib/assets/stylesheets/_nyulibraries.css.scss
@@ -18,5 +18,6 @@
 @import "nyulibraries/form";
 @import "nyulibraries/az";
 @import "nyulibraries/responsive";
+@import "nyulibraries/tables";
 @import "jquery/jquery-ui";
 

--- a/lib/assets/stylesheets/nyulibraries/_responsive.scss
+++ b/lib/assets/stylesheets/nyulibraries/_responsive.scss
@@ -31,6 +31,7 @@
   div.entree {
     margin-left: 30%;
   }
+
 }
 
 @media (max-width: 767px) {
@@ -100,6 +101,11 @@
         }
       }
     }
+  }
+  
+  form {
+    display: block !important;
+    float: none !important;
   }
 }
 

--- a/lib/assets/stylesheets/nyulibraries/_tables.scss
+++ b/lib/assets/stylesheets/nyulibraries/_tables.scss
@@ -1,0 +1,8 @@
+table {
+  tr {
+    td {
+      border: 1px solid $nyuLibrariesLightBorderColor;
+      padding: $paddingSmall;
+    }
+  }
+}

--- a/lib/assets/stylesheets/nyulibraries/_variables.scss
+++ b/lib/assets/stylesheets/nyulibraries/_variables.scss
@@ -7,6 +7,7 @@ $nyuLibrariesDarkBrown:                     #653d24 !default;
 $nyuLibrariesLightBrown:                    #E0D8C9 !default;
 $nyuLibrariesAzBlue:                        #0000ee !default;
 $nyuLibrariesBorderColor:                   #653d24 !default;
+$nyuLibrariesLightBorderColor:              #CCCCCC !default;
 $nyuLibrariesBackgroundColor:               #000000 !default;
 $maxSearchLabelWidth:                       140px !default;
 $searchBackgroundColor:                     darken(whiteSmoke, 5%) !default;


### PR DESCRIPTION
Specifically for Umbra/Blacklight these layout options need to exist but they are generally applicable to any templated application:

two_column function allows you to specify in your view that you only want it to be one column (i.e. in an admin panel where you don't want a sidebar)
body_class allows you to add class(es) to the body el
body_id same but with id el
onload adds onload text if necessary. this is not ideal in unobtrusive javascript but the blacklight layout uses it so i put it in there

Also I added a simple tables.scss file.
