### PR TITLE
added some link, nav tab and button stylings for NYU SH umlaut

### DIFF
--- a/lib/assets/stylesheets/_nyulibraries_nyush.scss
+++ b/lib/assets/stylesheets/_nyulibraries_nyush.scss
@@ -1,3 +1,4 @@
 @import "nyulibraries/nyush/variables";
 @import "nyulibraries";
 @import "nyulibraries/nyush/base";
+

--- a/lib/assets/stylesheets/nyulibraries/nyush/_base.scss
+++ b/lib/assets/stylesheets/nyulibraries/nyush/_base.scss
@@ -1,4 +1,61 @@
+$btnBackground: #5D0E8B;
+//$lightBtnBg: lighten( $btnBackground, 7% );
+
 body {
   max-width: 1280px;
   margin: 0 auto;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+
+.navbar-tabs .nav-tabs {
+    li > a {
+        color: $linkColor;
+        border-top-color: #eaeaea;
+        @include background-image( linear-gradient(#eaeaea, #ccc) );
+        @include transition(border-color 150ms ease, color 150ms ease);
+
+        &:hover {
+            color: #5D0E8B;
+            text-decoration: none;
+        }
+
+        &:active {
+            @include background-image( linear-gradient(#ccc, #eaeaea) );
+        }
+    }
+    li.active > a {
+        border-color: #fafafa;
+        background-image: none;
+    }
+}
+
+.btn {
+    background: $btnBackground;
+    color: #eaeaea;
+    text-shadow: 0 1px 1px rgba(55, 55, 55, 0.75);
+    @include transition(background 150ms ease);
+
+    &:hover {
+        color: #fafafa;
+        background: lighten( $btnBackground, 7% );
+    }
+}
+
+.search input[type="text"] {
+  background-color: $inputBackground;
+  border: 1px solid $inputBorder;
+  @include box-shadow(inset 0 1px 1px rgba(0,0,0,.075));
+  @include transition(border linear .2s, box-shadow linear .2s);
+
+  // Focus state
+  &:focus {
+    border-color: rgba($linkColor, .6);
+    outline: 0;
+    outline: thin dotted \9; /* IE6-9 */
+    @include box-shadow(inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba($linkColor,.6));
+  }
 }

--- a/lib/assets/stylesheets/nyulibraries/nyush/_variables.scss
+++ b/lib/assets/stylesheets/nyulibraries/nyush/_variables.scss
@@ -7,7 +7,7 @@ $linkColorHover: #5d0e8b;
 $searchBackgroundColor: #fafafa;
 $searchBorderColor: #eaeaea;
 $resultsBackgroundColor: #ddd;
-$tabBackgroundColor: #ccc;
 $activeTabBackgroundColor: #fafafa;
 $sidebarHeaderBackgroundColor: #ccc;
 $btnPrimaryBackground: #522f91;
+$tabBackgroundColor: #ccc;


### PR DESCRIPTION
A little customization to get us started. The rounded corners are used throughout so I left them alone, but I added a gradient on tabs and tweaked the colors to use NYU's purple and NYU Shanghai's red/pink in some places.

The Dummy app doesn't have any search result pages, so this can get us started and I guess I can tweak further once these styles are in the wild.
