### PR TITLE
Use "btn-default" Class for Button Dropdowns

### DIFF
--- a/app/helpers/nyulibraries/assets/html_helper.rb
+++ b/app/helpers/nyulibraries/assets/html_helper.rb
@@ -15,19 +15,19 @@ module Nyulibraries
 
       # Returns a Bootstrap button dropdown menu
       def button_dropdown(title, list, toggle_button = true)
-        dropdown(title, list, toggle_button, {class: ["btn-group"]}, {class: ["btn", "dropdown-toggle"]})
+        dropdown(title, list, toggle_button, {class: ["btn-group"]}, {class: ["btn", "btn-default", "dropdown-toggle"]})
       end
 
       # Returns a Bootstrap button dropdown menu, pulled right
       def right_button_dropdown(title, list, toggle_button = true)
-        dropdown(title, list, toggle_button, {class: ["btn-group", "pull-right"]}, {class: ["btn", "dropdown-toggle"]}, {class: ["pull-right", "dropdown-menu"]})
+        dropdown(title, list, toggle_button, {class: ["btn-group", "pull-right"]}, {class: ["btn", "btn-default", "dropdown-toggle"]}, {class: ["pull-right", "dropdown-menu"]})
       end
 
       # Returns a Bootstrap dropdown
       def dropdown(title, list, toggle_button = true, html_options = {:class => "dropdown"}, toggle_html_options = {class: "dropdown-toggle"}, menu_html_options={class: "dropdown-menu"})
         data_toggle_option = {data: {toggle: "dropdown"}}
         toggle_html_options.merge!(data_toggle_option)
-        button_html_options = {class: "btn"}
+        button_html_options = {class: ["btn", "btn-default"]}
         button_html_options.merge!(data_toggle_option) if toggle_button
         content_tag(:div, html_options) {
           content_tag(:button, title, button_html_options) +

--- a/app/helpers/nyulibraries/assets/html_helper.rb
+++ b/app/helpers/nyulibraries/assets/html_helper.rb
@@ -32,7 +32,7 @@ module Nyulibraries
         content_tag(:div, html_options) {
           content_tag(:button, title, button_html_options) +
           # Need to explicitly add margin-top for firefox. WTF?
-          content_tag(:button, toggle_html_options) { content_tag(:span, nil, class: "caret", style: "margin-top: 8px;") } +
+          content_tag(:button, toggle_html_options) { content_tag(:span, nil, class: "caret") } +
           content_tag(:ul, menu_html_options.merge(role: "menu")) {
             list.collect { |member|
               content_tag(:li){ member }

--- a/test/unit/helpers/nyulibraries/assets/html_helper_test.rb
+++ b/test/unit/helpers/nyulibraries/assets/html_helper_test.rb
@@ -3,16 +3,16 @@ module Nyulibraries
   module Assets
     class HtmlHelperTest < ActionView::TestCase
       test "check dropdown returns proper html" do
-        button_html = "<div class=\"btn-group\"><button class=\"btn\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        button_html = "<div class=\"btn-group\"><button class=\"btn btn-default\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal button_html, button_dropdown("Test Title", ["Test Value 1","Test Value 2"])
-        button_html_toggle_off = "<div class=\"btn-group\"><button class=\"btn\">Test Title</button><button class=\"btn dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        button_html_toggle_off = "<div class=\"btn-group\"><button class=\"btn btn-default\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal button_html_toggle_off, button_dropdown("Test Title", ["Test Value 1","Test Value 2"], false)
       end
 
       test "check right button dropdown returns proper html" do
-        right_button_html = "<div class=\"btn-group pull-right\"><button class=\"btn\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        right_button_html = "<div class=\"btn-group pull-right\"><button class=\"btn btn-default\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal right_button_html,right_button_dropdown("Test Title", ["Test Value 1","Test Value 2"])
-        right_button_html_toggle_off = "<div class=\"btn-group pull-right\"><button class=\"btn\">Test Title</button><button class=\"btn dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        right_button_html_toggle_off = "<div class=\"btn-group pull-right\"><button class=\"btn btn-default\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal right_button_html_toggle_off,right_button_dropdown("Test Title", ["Test Value 1","Test Value 2"], false)
       end
 

--- a/test/unit/helpers/nyulibraries/assets/html_helper_test.rb
+++ b/test/unit/helpers/nyulibraries/assets/html_helper_test.rb
@@ -3,16 +3,16 @@ module Nyulibraries
   module Assets
     class HtmlHelperTest < ActionView::TestCase
       test "check dropdown returns proper html" do
-        button_html = "<div class=\"btn-group\"><button class=\"btn btn-default\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        button_html = "<div class=\"btn-group\"><button class=\"btn btn-default\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal button_html, button_dropdown("Test Title", ["Test Value 1","Test Value 2"])
-        button_html_toggle_off = "<div class=\"btn-group\"><button class=\"btn btn-default\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        button_html_toggle_off = "<div class=\"btn-group\"><button class=\"btn btn-default\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\"></span></button><ul class=\"dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal button_html_toggle_off, button_dropdown("Test Title", ["Test Value 1","Test Value 2"], false)
       end
 
       test "check right button dropdown returns proper html" do
-        right_button_html = "<div class=\"btn-group pull-right\"><button class=\"btn btn-default\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        right_button_html = "<div class=\"btn-group pull-right\"><button class=\"btn btn-default\" data-toggle=\"dropdown\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal right_button_html,right_button_dropdown("Test Title", ["Test Value 1","Test Value 2"])
-        right_button_html_toggle_off = "<div class=\"btn-group pull-right\"><button class=\"btn btn-default\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\" style=\"margin-top: 8px;\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
+        right_button_html_toggle_off = "<div class=\"btn-group pull-right\"><button class=\"btn btn-default\">Test Title</button><button class=\"btn btn-default dropdown-toggle\" data-toggle=\"dropdown\"><span class=\"caret\"></span></button><ul class=\"pull-right dropdown-menu\" role=\"menu\"><li>Test Value 1</li><li>Test Value 2</li></ul></div>"
         assert_equal right_button_html_toggle_off,right_button_dropdown("Test Title", ["Test Value 1","Test Value 2"], false)
       end
 


### PR DESCRIPTION
@barnabyalter, @hab278 uses the "btn-default" class for styling button dropdowns, which is a little cleaner IMO
http://getbootstrap.com/css/#buttons-options