### PR TITLE
Maximize Max-Width on Workspace Popover

### DIFF
--- a/lib/assets/stylesheets/nyulibraries/_bobcat.scss
+++ b/lib/assets/stylesheets/nyulibraries/_bobcat.scss
@@ -1,5 +1,6 @@
 .popover {
   .workspace {
     width: 500px;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
@barnabyalter, @hab278 uses full width for workspace popover maximum width