### PR TITLE
Update _header.scss

### DIFF
--- a/lib/assets/stylesheets/nyulibraries/hsl/_header.scss
+++ b/lib/assets/stylesheets/nyulibraries/hsl/_header.scss
@@ -17,3 +17,7 @@ header {
   }
 }
 
+//Hide login and e-shelf option
+.nyu-login, .eshelf{
+display:none;
+}


### PR DESCRIPTION
Hide login and e-shelf options since Medical Center patrons are confused when they are asked to login with a NetID, but have a KID and cannot login.