### PR TITLE
Update _header.scss

### DIFF
--- a/lib/assets/stylesheets/nyulibraries/hsl/_header.scss
+++ b/lib/assets/stylesheets/nyulibraries/hsl/_header.scss
@@ -6,8 +6,7 @@ header {
 	border-bottom:0px;
 	border-top:5px solid #4E4E4E;
   
-  a {
-	width: 461px!important;
+  .parent a {
 	height: 59px!important;
 	background-image: url('http://hsl.med.nyu.edu/sites/default/files/primo/nyuhsl_identity.png')!important;
 	background-position: center!important;


### PR DESCRIPTION
There's a duplicate NYU HSL image on this page: https://login.library.nyu.edu/login
This should update the CSS to remove the second one on the right-hand side.