### PR TITLE
Update institutions.yml

### DIFF
--- a/config/institutions.yml
+++ b/config/institutions.yml
@@ -218,7 +218,7 @@ HSL:
     css: application_hsl
     dir: hsl
     breadcrumbs:
-      title: NYU Health Sciences Libraries
+      title: NYU Health Sciences Library
       url: http://hsl.med.nyu.edu/
     tabs:
       all:


### PR DESCRIPTION
The NYU HSL has become "singular" rather than plural, so the breadcrumb needs to say, "NYU Health Sciences Library"

I don't know the implications for changing "name: NYU Health Sciences Libraries" which appears above the breadcrumb, so I haven't made that change. It may be that's behind the scenes, so not seen by any user which is fine.

Thank you